### PR TITLE
attribute.go: Return trimmed string

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -69,7 +69,7 @@ func (attrib *Attribute) Read() (str string, err error) {
 	if err != nil {
 		return "", err
 	}
-	return string(data), nil
+	return strings.TrimSpace(string(data)), nil
 }
 
 func (attrib *Attribute) Write(value string) (err error) {
@@ -231,8 +231,6 @@ func (attrib *Attribute) ReadUint64() (value uint64, err error) {
 	if err != nil {
 		return 0, err
 	}
-
-	s = strings.TrimSpace(s)
 
 	return strconv.ParseUint(s, 10, 64)
 }


### PR DESCRIPTION
I'm using sysfs library in accessing leds and when run ReadInt I got:

panic: strconv.Atoi: parsing "0\n": invalid syntax

Signed-off-by: Marek Belisko <marek.belisko@open-nandra.com>